### PR TITLE
Creates both way conversions between barcode and written code

### DIFF
--- a/lib/payments_barcode.ex
+++ b/lib/payments_barcode.ex
@@ -62,6 +62,24 @@ defmodule PaymentsBarcode do
   def to_written_code(%Boleto{} = data), do: Boleto.to_written_code(data)
   def to_written_code(%GDA{} = data), do: GDA.to_written_code(data)
 
+  @doc "Try to convert from a barcode to a written code"
+  @spec from_barcode_to_written_code(String.t()) :: String.t() | :error
+  def from_barcode_to_written_code(code) do
+    case from_barcode(code) do
+      {:ok, barcode} -> to_written_code(barcode)
+      :error -> :error
+    end
+  end
+
+  @doc "Try to convert from a written code to a barcode"
+  @spec from_written_code_to_barcode(String.t()) :: String.t() | :error
+  def from_written_code_to_barcode(code) do
+    case from_written_code(code) do
+      {:ok, barcode} -> to_barcode(barcode)
+      :error -> :error
+    end
+  end
+
   defp try_parse(fns, code) do
     fns
     |> Stream.map(& &1.(code))

--- a/test/payments_barcode_test.exs
+++ b/test/payments_barcode_test.exs
@@ -98,6 +98,36 @@ defmodule PaymentsBarcodeTest do
     end
   end
 
+  describe "Convertion from barcode to written_code" do
+    test "when the code is a Barcode" do
+      assert from_barcode_to_written_code(@boleto_barcode_right) == @boleto_written_code_right
+    end
+
+    test "when the code is a GDA" do
+      assert from_barcode_to_written_code(@gda_barcode_right) == @gda_written_code_right
+    end
+
+    test "when convertion fails" do
+      assert from_barcode_to_written_code(@boleto_barcode_wrong) == :error
+      assert from_barcode_to_written_code(@gda_barcode_wrong) == :error
+    end
+  end
+
+  describe "Convertion from written_code to barcode" do
+    test "when the code is a Barcode" do
+      assert from_written_code_to_barcode(@boleto_written_code_right) == @boleto_barcode_right
+    end
+
+    test "when the code is a GDA" do
+      assert from_written_code_to_barcode(@gda_written_code_right) == @gda_barcode_right
+    end
+
+    test "when convertion fails" do
+      assert from_written_code_to_barcode(@boleto_written_code_wrong) == :error
+      assert from_written_code_to_barcode(@gda_written_code_wrong) == :error
+    end
+  end
+
   test "it doesnt crash with non-binary values" do
     assert :error = from_code(1234)
   end


### PR DESCRIPTION
While using this lib, i missed an easy way to convert from any given barcode to a written code and vice-versa.

This PR creates two functions in the API to do this.